### PR TITLE
WIP: Refactor compare warning

### DIFF
--- a/client/src/boot/registerComponents.js
+++ b/client/src/boot/registerComponents.js
@@ -6,6 +6,7 @@ import HistoryViewerVersion from 'components/HistoryViewer/HistoryViewerVersion'
 import HistoryViewerVersionDetail from 'components/HistoryViewer/HistoryViewerVersionDetail';
 import HistoryViewerVersionList from 'components/HistoryViewer/HistoryViewerVersionList';
 import HistoryViewerVersionState from 'components/HistoryViewer/HistoryViewerVersionState';
+import HistoryViewerCompareWarning from 'components/HistoryViewer/HistoryViewerCompareWarning';
 
 export default () => {
   Injector.component.registerMany({
@@ -16,6 +17,7 @@ export default () => {
     HistoryViewerVersionDetail,
     HistoryViewerVersionList,
     HistoryViewerVersionState,
+    HistoryViewerCompareWarning,
   });
 };
 

--- a/client/src/components/HistoryViewer/HistoryViewer.js
+++ b/client/src/components/HistoryViewer/HistoryViewer.js
@@ -8,7 +8,7 @@ import historyViewerConfig from 'containers/HistoryViewer/HistoryViewerConfig';
 import i18n from 'i18n';
 import { inject } from 'lib/Injector';
 import Loading from 'components/Loading/Loading';
-import { setCurrentPage, showVersion, setCompareMode } from 'state/historyviewer/HistoryViewerActions';
+import { setCurrentPage, showVersion } from 'state/historyviewer/HistoryViewerActions';
 import { versionType } from 'types/versionType';
 
 /**
@@ -23,7 +23,6 @@ class HistoryViewer extends Component {
     this.handleSetPage = this.handleSetPage.bind(this);
     this.handleNextPage = this.handleNextPage.bind(this);
     this.handlePrevPage = this.handlePrevPage.bind(this);
-    this.handleDismissCompare = this.handleDismissCompare.bind(this);
   }
 
   /**
@@ -124,33 +123,6 @@ class HistoryViewer extends Component {
     this.handleSetPage(currentPage - 1);
   }
 
-  handleDismissCompare() {
-    this.props.onDismissCompare();
-  }
-
-  /**
-   * Renders a notice indicating the user is in compare mode (iff compare mode is active)
-   *
-   * @returns {string}
-   */
-  renderCompareWarning() {
-    if (!this.props.compareMode) {
-      return '';
-    }
-
-    return (
-      <div className="history-viewer__compare-notice">
-        <span className="notice-message">
-          <strong>{i18n._t('HistoryViewer.COMPARE_MODE', 'Compare mode')}: </strong>
-          {i18n._t('HistoryViewer.SELECT_PROMPT', 'Select two versions')}
-        </span>
-        <button className="btn dismiss-button font-icon-cancel" onClick={this.handleDismissCompare}>
-          {i18n._t('HistoryViewer.EXIT', 'Exit')}
-        </button>
-      </div>
-    );
-  }
-
   /**
    * Renders the detail form for a selected version
    *
@@ -241,11 +213,11 @@ class HistoryViewer extends Component {
    * @returns {HistoryViewerVersionList}
    */
   renderVersionList() {
-    const { isPreviewable, ListComponent, onSelect } = this.props;
+    const { isPreviewable, ListComponent, onSelect, CompareWarningComponent } = this.props;
 
     return (
       <div className="history-viewer fill-height">
-        {this.renderCompareWarning()}
+        <CompareWarningComponent />
         <div className={isPreviewable ? 'panel panel--padded panel--scrollable' : ''}>
           <ListComponent
             onSelect={onSelect}
@@ -262,6 +234,7 @@ class HistoryViewer extends Component {
 
   renderCompareMode() {
     const { compareFrom, compareTo } = this.props;
+
     if (compareFrom && compareTo) {
         return this.renderVersionDetail();
     }
@@ -297,6 +270,7 @@ HistoryViewer.propTypes = {
   compareMode: PropTypes.bool,
   isPreviewable: PropTypes.bool,
   VersionDetailComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  CompareWarningComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   versions: PropTypes.shape({
     Versions: PropTypes.shape({
       pageInfo: PropTypes.shape({
@@ -356,9 +330,6 @@ function mapDispatchToProps(dispatch) {
     onSetPage(page) {
       dispatch(setCurrentPage(page));
     },
-    onDismissCompare() {
-      dispatch(setCompareMode(false));
-    },
   };
 }
 
@@ -368,10 +339,11 @@ export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   historyViewerConfig,
   inject(
-    ['HistoryViewerVersionList', 'HistoryViewerVersionDetail'],
-    (HistoryViewerVersionList, HistoryViewerVersionDetail) => ({
+    ['HistoryViewerVersionList', 'HistoryViewerVersionDetail', 'HistoryViewerCompareWarning'],
+    (HistoryViewerVersionList, HistoryViewerVersionDetail, HistoryViewerCompareWarning) => ({
       ListComponent: HistoryViewerVersionList,
       VersionDetailComponent: HistoryViewerVersionDetail,
+      CompareWarningComponent: HistoryViewerCompareWarning,
     }),
     ({ contextKey }) => `VersionedAdmin.HistoryViewer.${contextKey}`
   )

--- a/client/src/components/HistoryViewer/HistoryViewer.scss
+++ b/client/src/components/HistoryViewer/HistoryViewer.scss
@@ -90,13 +90,17 @@
 }
 
 .history-viewer__compare-notice {
-  margin: 0 auto;
+  align-self: center;
   background-color: lighten($color-notice, 13%);
   color: darken($color-notice, 35%);
   border: 1px solid $color-notice;
   border-top: none;
   border-bottom-right-radius: 5px;
   border-bottom-left-radius: 5px;
+
+  &.fixed {
+    position: absolute;
+  }
 
   .notice-message {
     padding: .4rem 1rem .4rem 1.5rem;

--- a/client/src/components/HistoryViewer/HistoryViewerCompareWarning.js
+++ b/client/src/components/HistoryViewer/HistoryViewerCompareWarning.js
@@ -1,0 +1,80 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import i18n from 'i18n';
+import { setCompareMode } from 'state/historyviewer/HistoryViewerActions';
+import classNames from 'classnames';
+
+class HistoryViewerCompareWarning extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleDismissCompare = this.handleDismissCompare.bind(this);
+  }
+
+  handleDismissCompare() {
+    this.props.onDismissCompare();
+  }
+
+  /**
+   * Renders a notice indicating the user is in compare mode (iff compare mode is active)
+   *
+   * @returns {string}
+   */
+  render() {
+    const { compareMode, fixed } = this.props;
+
+    if (!compareMode) {
+      return null;
+    }
+
+    const classes = ['history-viewer__compare-notice'];
+
+    if (fixed) {
+      classes.push('fixed');
+    }
+
+    return (
+      <div className={classNames(classes)}>
+        <span className="notice-message">
+          <strong>{i18n._t('HistoryViewer.COMPARE_MODE', 'Compare mode')}: </strong>
+          {i18n._t('HistoryViewer.SELECT_PROMPT', 'Select two versions')}
+        </span>
+        <button className="btn dismiss-button font-icon-cancel" onClick={this.handleDismissCompare}>
+          {i18n._t('HistoryViewer.EXIT', 'Exit')}
+        </button>
+      </div>
+    );
+  }
+}
+
+HistoryViewerCompareWarning.propTypes = {
+  compareMode: PropTypes.bool.isRequired,
+  fixed: PropTypes.bool.isRequired,
+};
+
+HistoryViewer.defaultProps = {
+  fixed: false,
+};
+
+function mapStateToProps(state) {
+  const {
+    compareMode,
+  } = state.versionedAdmin.historyViewer;
+
+  return {
+    compareMode,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onDismissCompare() {
+      dispatch(setCompareMode(false));
+    },
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(HistoryViewerCompareWarning);

--- a/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
@@ -68,7 +68,8 @@ class HistoryViewerVersionDetail extends PureComponent {
       recordId,
       schemaUrl,
       ToolbarComponent,
-      version
+      CompareWarningComponent,
+      version,
     } = this.props;
 
     const containerClasses = isPreviewable ? 'panel panel--padded panel--padded-side panel--scrollable' : '';
@@ -97,6 +98,8 @@ class HistoryViewerVersionDetail extends PureComponent {
             recordId={recordId}
             versionId={version.Version}
           />
+
+          <CompareWarningComponent fixed />
         </div>
 
         {this.getPreview()}
@@ -124,11 +127,12 @@ HistoryViewerVersionDetail.defaultProps = {
 export { HistoryViewerVersionDetail as Component };
 
 export default inject(
-  ['HistoryViewerVersionList', 'HistoryViewerToolbar', 'Preview'],
-  (ListComponent, ToolbarComponent, PreviewComponent) => ({
+  ['HistoryViewerVersionList', 'HistoryViewerToolbar', 'Preview', 'HistoryViewerCompareWarning'],
+  (ListComponent, ToolbarComponent, PreviewComponent, CompareWarningComponent) => ({
     ListComponent,
     ToolbarComponent,
     PreviewComponent,
+    CompareWarningComponent,
   }),
   ({ version }, context) => `${context}.HistoryViewerVersionDetail.${version.Version}`
 )(HistoryViewerVersionDetail);


### PR DESCRIPTION
Original unit of work was to have the warning message show on the detail view also. This involved:
- Extracting the message into an individual component
- Using that new component in `HistoryViewer`
- Adding that new component to `HistroyViewerVersionDetail`

Additionally, I accidentally made it behave as if it was fixed. No idea if the designs want this but I'll wait for feedback from UX. __Before this can be merged__ I need to clarify:
- Should it behave like it's fixed?
- Should we change the text as being prompted to "select two versions" makes no sense when two version have already been selected.