### PR TITLE
Fixing selecting two rows in list view

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewer.js
+++ b/client/src/components/HistoryViewer/HistoryViewer.js
@@ -158,7 +158,7 @@ class HistoryViewer extends Component {
     
     const filterVersions = (wantedID) => (potential => potential.Version === wantedID);
 
-    const version = this.getVersions().find(filterVersions(currentVersion));
+    const version = this.getVersions().find(filterVersions(compareMode ? compareFrom : currentVersion));
     const latestVersion = this.getLatestVersion();
     const compare = compareMode ? {
       versionFrom: this.getVersions().find(filterVersions(compareFrom)),

--- a/client/src/components/HistoryViewer/HistoryViewer.scss
+++ b/client/src/components/HistoryViewer/HistoryViewer.scss
@@ -22,10 +22,10 @@
   margin-left: 10px;
 }
 
-.history-viewer__row--current {
+.table .history-viewer__row--current {
   // There will only be one table row in this table state
   &, &:hover {
-    background-color: $link-color !important;
+    background-color: $link-color;
     color: $white;
   }
 

--- a/client/src/components/HistoryViewer/HistoryViewer.scss
+++ b/client/src/components/HistoryViewer/HistoryViewer.scss
@@ -22,11 +22,10 @@
   margin-left: 10px;
 }
 
-.history-viewer__table--current {
+.history-viewer__row--current {
   // There will only be one table row in this table state
-  tbody tr,
-  tbody tr:hover {
-    background-color: $link-color;
+  &, &:hover {
+    background-color: $link-color !important;
     color: $white;
   }
 

--- a/client/src/components/HistoryViewer/HistoryViewerHeading.js
+++ b/client/src/components/HistoryViewer/HistoryViewerHeading.js
@@ -33,15 +33,17 @@ class HistoryViewerHeading extends Component {
   }
 
   render() {
-    const { compareModeSelected, hasActions } = this.props;
+    const { compareModeSelected } = this.props;
     const { dropdownOpen } = this.state;
 
     return (
       <tr className="history-viewer__heading">
         <th>#</th>
         <th>{i18n._t('HistoryViewer.Record', 'Record')}</th>
-        <th className="author-compare-toggle__container">
+        <th>
           <span className="author-span">{i18n._t('HistoryViewer.Author', 'Author')}</span>
+        </th>
+        <th className="author-compare-toggle__container">
           <Dropdown
             isOpen={dropdownOpen}
             toggle={this.toggle}
@@ -64,21 +66,15 @@ class HistoryViewerHeading extends Component {
             </DropdownMenu>
           </Dropdown>
         </th>
-        {hasActions ? <th /> : null}
       </tr>
     );
   }
 }
 
 HistoryViewerHeading.propTypes = {
-  hasActions: PropTypes.bool,
   compareModeSelected: PropTypes.bool,
   onCompareModeSelect: PropTypes.func,
   onCompareModeUnselect: PropTypes.func,
-};
-
-HistoryViewerHeading.defaultProps = {
-  hasActions: false,
 };
 
 function mapStateToProps(state) {

--- a/client/src/components/HistoryViewer/HistoryViewerVersion.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersion.js
@@ -103,7 +103,11 @@ class HistoryViewerVersion extends Component {
    * @returns {FormAction|null}
    */
   renderClearButton() {
-    const { FormActionComponent } = this.props;
+    const { FormActionComponent, isActive } = this.props;
+
+    if (!isActive) {
+      return null;
+    }
 
     return (
       <FormActionComponent
@@ -122,10 +126,12 @@ class HistoryViewerVersion extends Component {
    * @returns {DOMElement}
    */
   renderActions() {
-    const { isActive } = this.props;
+    const { isActive, compareMode } = this.props;
 
-    if (!isActive) {
-      return null;
+    if (!isActive && !compareMode) {
+      return (
+        <td />
+      );
     }
 
     return (
@@ -140,7 +146,7 @@ class HistoryViewerVersion extends Component {
     const { version, isActive, StateComponent } = this.props;
 
     return (
-      <tr onClick={this.handleClick}>
+      <tr className={isActive ? 'history-viewer__row--current' : ''} onClick={this.handleClick}>
         <td>{version.Version}</td>
         <td>
           <StateComponent
@@ -172,9 +178,11 @@ HistoryViewerVersion.defaultProps = {
 };
 
 function mapStateToProps(state) {
+  const { compareMode, compareFrom } = state.versionedAdmin.historyViewer;
+
   return {
-    compareMode: state.versionedAdmin.historyViewer.compareMode,
-    compareFrom: state.versionedAdmin.historyViewer.compareFrom,
+    compareMode,
+    compareFrom,
   };
 }
 

--- a/client/src/components/HistoryViewer/HistoryViewerVersionList.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionList.js
@@ -18,6 +18,18 @@ class HistoryViewerVersionList extends PureComponent {
     return classnames({ table: true }, extraClass);
   }
 
+  isVersionActive(version) {
+    const { isActive, compareFrom, compareTo } = this.props;
+
+    // "isActive" in this component indicates that the content is shown - ie. the table only shows the row (or rows)
+    // that are currently highlighted above the content of this version.
+    if (isActive) {
+      return true;
+    }
+
+    return version.Version === compareFrom || version.Version === compareTo
+  }
+
   /**
    * Render any messages into the form
    *
@@ -47,7 +59,7 @@ class HistoryViewerVersionList extends PureComponent {
   }
 
   render() {
-    const { HeadingComponent, isActive, VersionComponent, versions } = this.props;
+    const { HeadingComponent, VersionComponent, versions } = this.props;
 
     return (
       <div>
@@ -62,7 +74,7 @@ class HistoryViewerVersionList extends PureComponent {
               versions.map((version) => (
                 <VersionComponent
                   key={version.Version}
-                  isActive={isActive}
+                  isActive={this.isVersionActive(version)}
                   version={version}
                 />
               ))
@@ -82,6 +94,8 @@ HistoryViewerVersionList.propTypes = {
   messages: PropTypes.arrayOf(messageType),
   VersionComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   versions: PropTypes.arrayOf(versionType),
+  compareFrom: versionType,
+  compareTo: versionType,
 };
 
 HistoryViewerVersionList.defaultProps = {
@@ -92,9 +106,9 @@ HistoryViewerVersionList.defaultProps = {
 };
 
 function mapStateToProps(state) {
-  const { messages } = state.versionedAdmin.historyViewer;
+  const { messages, compareFrom, compareTo } = state.versionedAdmin.historyViewer;
   return {
-    messages,
+    messages, compareFrom, compareTo
   };
 }
 

--- a/client/src/components/HistoryViewer/tests/HistoryViewerHeading-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerHeading-test.js
@@ -17,7 +17,6 @@ describe('HistoryViewerHeading', () => {
     describe('simulate change event in enabled compare mode', () => {
       const wrapper = shallow(
         <HistoryViewerHeading
-          hasActions={false}
           compareModeSelected
           onCompareModeSelect={mockOnCompareModeSelect}
           onCompareModeUnselect={mockOnCompareModeUnselect}
@@ -33,7 +32,6 @@ describe('HistoryViewerHeading', () => {
     describe('simulate change event in disabled compare mode', () => {
       const wrapper = shallow(
         <HistoryViewerHeading
-          hasActions={false}
           compareModeSelected={false}
           onCompareModeSelect={mockOnCompareModeSelect}
           onCompareModeUnselect={mockOnCompareModeUnselect}
@@ -59,18 +57,5 @@ describe('HistoryViewerHeading', () => {
       );
     }
   }
-
-  it('has four columns when hasActions is true', () => {
-    const component = ReactTestUtils.renderIntoDocument(
-      <HeadingWrapper hasActions />
-    );
-
-    const result = ReactTestUtils.scryRenderedDOMComponentsWithTag(
-      component,
-      'th'
-    );
-
-    expect(result.length).toBe(4);
-  });
 });
 

--- a/client/src/state/historyviewer/HistoryViewerReducer.js
+++ b/client/src/state/historyviewer/HistoryViewerReducer.js
@@ -79,18 +79,22 @@ export default function historyViewerReducer(state = initialState, { type, paylo
     }
 
     case HISTORY_VIEWER.SET_COMPARE_FROM: {
-      let { compareFrom, compareTo } = state;
+      let { compareFrom, compareTo, currentVersion } = state;
       compareFrom = payload.version;
 
       if (!payload.version) {
         compareFrom = compareTo;
         compareTo = 0;
       }
+      else if (!currentVersion) {
+        currentVersion = compareFrom;
+      }
 
       return {
         ...state,
         compareFrom,
         compareTo,
+        currentVersion,
       };
     }
 

--- a/client/src/state/historyviewer/HistoryViewerReducer.js
+++ b/client/src/state/historyviewer/HistoryViewerReducer.js
@@ -79,22 +79,18 @@ export default function historyViewerReducer(state = initialState, { type, paylo
     }
 
     case HISTORY_VIEWER.SET_COMPARE_FROM: {
-      let { compareFrom, compareTo, currentVersion } = state;
+      let { compareFrom, compareTo } = state;
       compareFrom = payload.version;
 
       if (!payload.version) {
         compareFrom = compareTo;
         compareTo = 0;
       }
-      else if (!currentVersion) {
-        currentVersion = compareFrom;
-      }
 
       return {
         ...state,
         compareFrom,
         compareTo,
-        currentVersion,
       };
     }
 


### PR DESCRIPTION
This PR fixes the UI when choosing to select two versions to compare from the list screen.

I also made the actions column always render, because is was causing some awkward jittering as things became visible.