### PR TITLE
minor 'truth adjustment' for docblocks

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
@@ -16,8 +16,10 @@ class HistoryViewerVersionDetail extends PureComponent {
   }
 
   /**
-   * A useful doc block explaining why we construct an array of versions in each case (noting that
-   * it previously was hard coded to return an array containing the current version only).
+   * Originally this component hard coded the array of versions to be passed
+   * to the list component as [version], but with the introduction of a compare mode
+   * this isn't always true (we need both "compare from" & "compare to").
+   * So this getter abstracts that logic.
    *
    * @returns {Array}
    */
@@ -31,7 +33,7 @@ class HistoryViewerVersionDetail extends PureComponent {
 
   /*
    * Return whether or not we should be displaying the preview component
-   * @return bool
+   * @return {Boolean}
    */
   isPreviewable() {
     const { isPreviewable } = this.props;
@@ -40,7 +42,7 @@ class HistoryViewerVersionDetail extends PureComponent {
 
   /*
    * Return whether or not we should be comparing two versions
-   * @return bool
+   * @return {Boolean}
    */
   isCompareMode() {
     const { compare } = this.props;

--- a/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
@@ -33,7 +33,7 @@ class HistoryViewerVersionDetail extends PureComponent {
 
   /*
    * Return whether or not we should be displaying the preview component
-   * @return {boolean}
+   * @returns {boolean}
    */
   isPreviewable() {
     const { isPreviewable } = this.props;
@@ -42,7 +42,7 @@ class HistoryViewerVersionDetail extends PureComponent {
 
   /*
    * Return whether or not we should be comparing two versions
-   * @return {boolean}
+   * @returns {boolean}
    */
   isCompareMode() {
     const { compare } = this.props;

--- a/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
@@ -21,7 +21,7 @@ class HistoryViewerVersionDetail extends PureComponent {
    * this isn't always true (we need both "compare from" & "compare to").
    * So this getter abstracts that logic.
    *
-   * @returns {Array}
+   * @returns {array}
    */
   getListVersions() {
     const { compare, version } = this.props;
@@ -33,7 +33,7 @@ class HistoryViewerVersionDetail extends PureComponent {
 
   /*
    * Return whether or not we should be displaying the preview component
-   * @return {Boolean}
+   * @return {boolean}
    */
   isPreviewable() {
     const { isPreviewable } = this.props;
@@ -42,7 +42,7 @@ class HistoryViewerVersionDetail extends PureComponent {
 
   /*
    * Return whether or not we should be comparing two versions
-   * @return {Boolean}
+   * @return {boolean}
    */
   isCompareMode() {
     const { compare } = this.props;


### PR DESCRIPTION
I recently added some docblocks that mentioned that they were docblocks and should contain relevant information (which itself is irrelevant information, in that context).