### PR TITLE
FIX SET_COMPARE_MODE reducer no longer clears previously set compareFrom value

### DIFF
--- a/client/src/state/historyviewer/HistoryViewerReducer.js
+++ b/client/src/state/historyviewer/HistoryViewerReducer.js
@@ -68,6 +68,7 @@ export default function historyViewerReducer(state = initialState, { type, paylo
         compare = {
           versionFrom: 0,
           versionTo: 0,
+          ...state.compare,
         };
       }
 

--- a/client/src/state/historyviewer/tests/HistoryViewerReducer-test.js
+++ b/client/src/state/historyviewer/tests/HistoryViewerReducer-test.js
@@ -106,6 +106,21 @@ describe('HistoryViewerReducer', () => {
 
       expect(result.compare).toBe(false);
     });
+
+    it('leaves the existing value for compareFrom when enabling', () => {
+      state = {
+        ...state,
+        compare: { ...state.compare, versionFrom: 1 },
+      };
+
+      const result = historyViewerReducer(state, {
+        type: 'HISTORY_VIEWER.SET_COMPARE_MODE',
+        payload: { enabled: true },
+      });
+
+      expect(result.compare.versionFrom).toBe(1);
+      expect(result.compare.versionTo).toBe(0);
+    });
   });
 
   describe('SET_COMPARE_FROM', () => {


### PR DESCRIPTION
We can merge the values rather giving priority to existing values, rather than overwrite them. Previously the SET_COMPARE_FROM reduction would set ![image](https://user-images.githubusercontent.com/5170590/43058166-3022ea96-8e9a-11e8-943a-868c178e3cce.png) then would be overridden back to zero by SET_COMPARE_MODE.
